### PR TITLE
Setting to always build in Release mode

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(realsense2_camera)
 
+set(CMAKE_BUILD_TYPE Release)
 option(BUILD_WITH_OPENMP "Use OpenMP" OFF)
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
We will likely want to revert this commit in the future but we're doing it now so we don't have to build the rest of our system in release mode, thereby introducing unnecessary risk at this point in time.