### PR TITLE
Hardware reset of realsense on SIGINT

### DIFF
--- a/realsense2_camera/include/realsense_node_factory.h
+++ b/realsense2_camera/include/realsense_node_factory.h
@@ -43,13 +43,6 @@ namespace realsense2_camera
 
     const std::vector<std::vector<stream_index_pair>> HID_STREAMS = {{GYRO, ACCEL}};
 
-    inline void signalHandler(int signum)
-    {
-        ROS_INFO_STREAM(strsignal(signum) << " Signal is received! Terminating RealSense Node...");
-        ros::shutdown();
-        exit(signum);
-    }
-
     class InterfaceRealSenseNode
     {
     public:


### PR DESCRIPTION
After restarting the realsense with the new v2.14.1 librealsense driver we often get this error:
```
30/07 13:01:01,549 WARNING [140468993460096] (types.cpp:57) get_xu(id=10) failed! Last Error: Input/output error
[ERROR] [1532980861.551923317]: An exception has been thrown: get_xu(id=10) failed! Last Error: Input/output error
[ERROR] [1532980861.551955229]: An exception has been thrown: get_xu(id=10) failed! Last Error: Input/output error
[FATAL] [1532980861.554830463]: Failed to load nodelet '/cameras/fryer/realsense2_camera` of type `realsense2_camera/RealSenseNodeFactory` to manager `realsense2_camera_manager'
[cameras/fryer/realsense2_camera-4] process has died [pid 19071, exit code 255, cmd /opt/ros/kinetic/lib/nodelet/nodelet load realsense2_camera/RealSenseNodeFactory realsense2_camera_manager __name:=realsense2_camera __log:=/home/zzv/.ros/log/44ce9208-9433-11e8-b2d7-6045cb84d761/cameras-fryer-realsense2_camera-4.log].
log file: /home/zzv/.ros/log/44ce9208-9433-11e8-b2d7-6045cb84d761/cameras-fryer-realsense2_camera-4*.log
```
And we must unplug and replug the realsense or restart the jetson to get it to work again.
This fix calls the hardware reset function on sigint so that next time the realsense will start correctly.