### PR TITLE
Feature/ir marker

### DIFF
--- a/realsense2_camera/cfg/base_d400_params.py
+++ b/realsense2_camera/cfg/base_d400_params.py
@@ -5,8 +5,8 @@ from dynamic_reconfigure.parameter_generator_catkin import *
 
 def add_base_params(gen, prefix):
   #             Name                                               Type    Level Description                  Default    Min     Max
-  gen.add(str(prefix) + "depth_gain",                              int_t,    1,  "Gain",                      16,        16,     248)
-  gen.add(str(prefix) + "depth_enable_auto_exposure",              bool_t,   2,  "Enable Auto Exposure",      True)
+  gen.add(str(prefix) + "depth_gain",                              int_t,    1,  "Gain",                      32,        16,     248)
+  gen.add(str(prefix) + "depth_enable_auto_exposure",              bool_t,   2,  "Enable Auto Exposure",      False)
   preset_enum = gen.enum([gen.const("Custom",        int_t,  0,  "Custom"),
                           gen.const("Default",       int_t,  1,  "Default Preset"),
                           gen.const("Hand",          int_t,  2,  "Hand Gesture"),

--- a/realsense2_camera/cfg/rs415_params.cfg
+++ b/realsense2_camera/cfg/rs415_params.cfg
@@ -12,8 +12,8 @@ base_d400_params.add_base_params(gen, "rs415_")
 
 #             Name                               Type       Level  Description                  Default    Min     Max
 gen.add("rs415_depth_enable_auto_white_balance", bool_t,    9,     "Enable Auto White Balance", False)
-gen.add("rs415_depth_exposure",                  int_t,     10,    "Exposure",                  1650,      1,      8300) # The exposure step is 20 by definition but the param step is 1 by default so we divided all values by 20 and multiply it back in SW
-gen.add("rs415_depth_laser_power",               double_t,  11,    "Laser Power",               12.5,      0,      12) # Multiple value by 30
+gen.add("rs415_depth_exposure",                  int_t,     10,    "Exposure",                  3000,      1,      8300) # The exposure step is 20 by definition but the param step is 1 by default so we divided all values by 20 and multiply it back in SW
+gen.add("rs415_depth_laser_power",               double_t,  11,    "Laser Power",               4.0,      0,      12.5) # Multiple value by 30
 emitter_enabled_enum = gen.enum([gen.const("Off",  int_t,  0,  "Off"),
                                  gen.const("On",   int_t,  1,  "On"),
                                  gen.const("Auto", int_t,  2,  "Auto")], "Depth Emitter")

--- a/realsense2_camera/launch/includes/nodelet.launch.xml
+++ b/realsense2_camera/launch/includes/nodelet.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="respawn"             default="false"/>
   <arg name="namespace"           default="camera"/>
   <arg name="manager"             default="realsense2_camera_manager"/>
   <arg name="serial_no"           default=""/>
@@ -64,8 +65,8 @@
   <arg name="aligned_depth_to_infra2_frame_id" default="$(arg namespace)/camera_aligned_depth_to_infra2_frame"/>
   <arg name="aligned_depth_to_fisheye_frame_id" default="$(arg namespace)/camera_aligned_depth_to_fisheye_frame"/>
 
-  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" output="screen"/>
-  <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)">
+  <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager" respawn="$(arg respawn)" output="screen"/>
+  <node pkg="nodelet" type="nodelet" name="realsense2_camera" args="load realsense2_camera/RealSenseNodeFactory $(arg manager)" respawn="$(arg respawn)">
     <param name="serial_no"                type="str"  value="$(arg serial_no)"/>
     <param name="json_file_path"           type="str"  value="$(arg json_file_path)"/>
 

--- a/realsense2_camera/launch/rs_rgbd.launch
+++ b/realsense2_camera/launch/rs_rgbd.launch
@@ -79,6 +79,9 @@ Processing enabled by this node:
   <arg name="enable_sync"         default="true"/>
   <arg name="align_depth"         default="true"/>
 
+  <arg name="pc_rgb"              default="true"/>
+  <arg name="pc_ir"               default="true"/>
+
   <!-- rgbd_launch specific arguments -->
 
   <!-- Arguments for remapping all device namespaces -->
@@ -88,6 +91,8 @@ Processing enabled by this node:
   <arg name="depth_registered_pub"            default="depth_registered" />
   <arg name="depth_registered"                default="depth_registered" unless="$(arg align_depth)" />
   <arg name="depth_registered"                default="aligned_depth_to_color" if="$(arg align_depth)" />
+  <arg name="depth_ir_registered_pub"         default="depth_ir_registered" />
+  <arg name="depth_ir_registered"             default="aligned_depth_to_infra1" if="$(arg align_depth)" />
   <arg name="depth_registered_filtered"       default="$(arg depth_registered)" />
   <arg name="projector"                       default="projector" />
 
@@ -148,6 +153,8 @@ Processing enabled by this node:
       <arg name="gyro_fps"                 value="$(arg gyro_fps)"/>
       <arg name="accel_fps"                value="$(arg accel_fps)"/>
       <arg name="enable_imu"               value="$(arg enable_imu)"/>
+
+      <arg name="respawn"                  value="$(arg respawn)" />
     </include>
 
     <!-- RGB processing -->
@@ -179,14 +186,34 @@ Processing enabled by this node:
     </group>
 
     <group if="$(eval depth_registered_processing and hw_registered_processing)">
-      <!-- Publish registered XYZRGB point cloud with hardware registered input (ROS Realsense depth alignment) -->
-      <node pkg="nodelet" type="nodelet" name="points_xyzrgb_hw_registered"
-            args="load depth_image_proc/point_cloud_xyzrgb $(arg manager) $(arg bond)" respawn="$(arg respawn)">
-        <remap from="rgb/image_rect_color"        to="$(arg rgb)/image_rect_color" />
-        <remap from="rgb/camera_info"             to="$(arg rgb)/camera_info" />
-        <remap from="depth_registered/image_rect" to="$(arg depth_registered)/image_raw" />
-        <remap from="depth_registered/points"     to="$(arg depth_registered_pub)/points" />
-      </node>
+      <group if="$(arg pc_rgb)">
+        <!-- Publish registered XYZRGB point cloud with hardware registered input (ROS Realsense depth alignment) -->
+        <node pkg="nodelet" type="nodelet" name="points_xyzrgb_hw_registered"
+              args="load depth_image_proc/point_cloud_xyzrgb $(arg manager) $(arg bond)" respawn="$(arg respawn)">
+          <remap from="rgb/image_rect_color"        to="$(arg rgb)/image_rect_color" />
+          <remap from="rgb/camera_info"             to="$(arg rgb)/camera_info" />
+          <remap from="depth_registered/image_rect" to="$(arg depth_registered)/image_raw" />
+          <remap from="depth_registered/points"     to="$(arg depth_registered_pub)/points" />
+        </node>
+      </group>
+
+      <group if="$(arg pc_ir)">
+        <!-- Convert IR from mono to color image -->
+        <node pkg="realsense2_camera" type="mono_to_color.py" name="mono_to_color" respawn="$(arg respawn)">
+          <param name="mono_image_topic" value="$(arg ir)/image_rect_raw"/>
+          <param name="color_image_topic" value="$(arg ir)/image_color"/>
+          <param name="frame_id" value="$(arg namespace)/camera_depth_optical_frame"/>
+        </node>
+
+        <!-- Publish registered XYZ IR point cloud with hardware registered input (ROS Realsense depth alignment) -->
+        <node pkg="nodelet" type="nodelet" name="points_xyz_ir1_hw_registered"
+              args="load depth_image_proc/point_cloud_xyzrgb $(arg manager) $(arg bond)" respawn="$(arg respawn)">
+          <remap from="rgb/image_rect_color"        to="$(arg ir)/image_color" />
+          <remap from="rgb/camera_info"             to="$(arg ir)/camera_info" />
+          <remap from="depth_registered/image_rect" to="$(arg depth)/image_rect_raw" />
+          <remap from="depth_registered/points"     to="$(arg depth_ir_registered_pub)/points" />
+        </node>
+      </group>
     </group>
 
   </group>

--- a/realsense2_camera/scripts/mono_to_color.py
+++ b/realsense2_camera/scripts/mono_to_color.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+import cv2
+from cv_bridge import CvBridge, CvBridgeError
+
+import rospy
+from sensor_msgs.msg import Image
+
+
+class MonoToColor(object):
+
+    def __init__(self):
+        rospy.init_node('mono_to_color')
+
+        mono_image_topic = rospy.get_param('~mono_image_topic')
+        color_image_topic = rospy.get_param('~color_image_topic')
+        self.__frame_id = rospy.get_param('~frame_id', None)
+
+        self.__bridge = CvBridge()
+
+        self.__color_image_pub = rospy.Publisher(color_image_topic,
+                                                 Image,
+                                                 queue_size=1)
+
+        self.__mono_image_sub = rospy.Subscriber(mono_image_topic,
+                                                 Image,
+                                                 self.__image_callback,
+                                                 queue_size=1)
+
+        rospy.loginfo('Initialized %s successfully.', self.__class__.__name__)
+
+    def __image_callback(self, mono_image_msg):
+        try:
+            mono_image = self.__bridge.imgmsg_to_cv2(
+                mono_image_msg, 'passthrough')
+            color_image = cv2.cvtColor(mono_image, cv2.COLOR_GRAY2RGB)
+            color_image_msg = self.__bridge.cv2_to_imgmsg(color_image, 'rgb8')
+            rospy.loginfo('Converted mono to color image.')
+            color_image_msg.header = mono_image_msg.header
+            if self.__frame_id:
+                color_image_msg.header.frame_id = self.__frame_id
+            self.__color_image_pub.publish(color_image_msg)
+        except CvBridgeError as e:
+            rospy.logerr(e)
+
+
+if __name__ == '__main__':
+    MonoToColor()
+    rospy.spin()


### PR DESCRIPTION
Add toggle for IR and RGB pointcloud and change default params

Change default rqt_reconfigure params for depth_enable_auto_exposure,
depth_exposure, depth_gain, and depth_laser_power.
Raise depth_laser_power max to 12.5 and set default to 4.0 so that
the specular laser pattern doesn't interfere with marker detection.
Raise default depth_gain to 32 and default depth_exposure to 3000.

Add script to convert the mono IR image to a color image because the
pointcloud generation requires a 3-channel image. Also, add respawn
arg for camera nodes so they can restart automatically.