### PR TITLE
Disable static transform publishing

### DIFF
--- a/realsense2_camera/src/base_realsense_node.cpp
+++ b/realsense2_camera/src/base_realsense_node.cpp
@@ -87,7 +87,10 @@ void BaseRealSenseNode::publishTopics()
     setupDevice();
     setupPublishers();
     setupStreams();
-    publishStaticTransforms();
+
+    // NOTE: This is done in Miso software now.
+    //publishStaticTransforms();
+
     ROS_INFO_STREAM("RealSense Node Is Up!");
 }
 


### PR DESCRIPTION
This commit disables publishing of static transforms.  These are now
being published by the Miso calibration service.