### PR TITLE
Disable RealSense emitter by default

### DIFF
--- a/realsense2_camera/cfg/rs415_params.cfg
+++ b/realsense2_camera/cfg/rs415_params.cfg
@@ -17,7 +17,7 @@ gen.add("rs415_depth_laser_power",               double_t,  11,    "Laser Power"
 emitter_enabled_enum = gen.enum([gen.const("Off",  int_t,  0,  "Off"),
                                  gen.const("On",   int_t,  1,  "On"),
                                  gen.const("Auto", int_t,  2,  "Auto")], "Depth Emitter")
-gen.add("rs415_depth_emitter_enabled",           int_t,     12,    "Depth Emitter Enabled",     1,         0,      2, edit_method=emitter_enabled_enum)
+gen.add("rs415_depth_emitter_enabled",           int_t,     12,    "Depth Emitter Enabled",     0,         0,      2, edit_method=emitter_enabled_enum)
 
 gen.add("rs415_color_backlight_compensation",    bool_t,    13,    "Backlight Compensation",    False)
 gen.add("rs415_color_brightness",                int_t,     14,    "Brightness",                0,         -64,    64)


### PR DESCRIPTION
The projected IR pattern is interfering with marker detection now that
the markers are closer to the cameras.