### PR TITLE
Fix a missing dependency for topic_tools

### DIFF
--- a/realsense2_camera/package.xml
+++ b/realsense2_camera/package.xml
@@ -41,6 +41,7 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>tf</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
 
   <test_depend>roslaunch</test_depend>
 


### PR DESCRIPTION
This adds topic_tools as a dependency so the checks will pass.